### PR TITLE
Fix[workshop content]: add empty lines after headings

### DIFF
--- a/site/contents/materials/workshop/project-owners.md
+++ b/site/contents/materials/workshop/project-owners.md
@@ -1,10 +1,12 @@
 # Working with project owners
 
 ## Who can be a project owner?  
+
 Anyone using statistics or data science in their work! 
 We intend for the Data Hazards to be useful with all types of projects, including those still in their abstract phases. 
 
 ## What do the project owners need to do?  
+
 The main thing they need to prepare in advance is a description of their project, which is key to the workshop format. 
 Here are some things we recommend their 5-minute talk includes:  
 - The overall objective of the project


### PR DESCRIPTION


## Description
<!-- Please describe what you've added (bullet points are good!), and link to the issue that this Pull Request addresses, e.g. type "#5" if you're addressing issue number 5 and it will automatically create a link -->
Added empty lines after headings for the headings to render correctly in the page "[Working with project owners](https://datahazards.com/contents/materials/workshop/project-owners.html)"

## Checklist (contributor)
<!-- Contributors: please complete as much of this checklist as you can when you create this Pull Request.
Mark this Pull Request as Ready for Review when you're happy with all the changes you've made.
-->

- [x] Marked as draft
- [ ] Linked to issue
- [x] Filled in description
- [x] Gave this Pull Request a descriptive title
 
## Checklist (maintainer)
<!-- Maintainers: please check the following before you merge-->
- [ ] Built site locally.
- [ ] Changes are as discussed in issue.
- [ ] New pages are linked in the TOC/navigation?
- [ ] Have we added the contributor to our all-contributors?
- [ ] One sentence per line
